### PR TITLE
Fix progress bar completion

### DIFF
--- a/grok3-pro-simple.ts
+++ b/grok3-pro-simple.ts
@@ -150,7 +150,7 @@ async function main() {
   }
   let best = "";
   let bestVotes = -1;
-  for (const [ans, votes] of counts) {
+  for (const [ans, votes] of Array.from(counts.entries())) {
     if (votes > bestVotes) {
       best = ans;
       bestVotes = votes;
@@ -219,6 +219,8 @@ async function main() {
 
   // Mark final deliberation step complete in progress bar
   bar.increment();
+  // Adjust total to reflect actual work in case tasks finished early
+  bar.setTotal((bar as any).value);
   bar.stop();
 }
 

--- a/grok3-pro.ts
+++ b/grok3-pro.ts
@@ -264,6 +264,8 @@ async function main() {
 
   // Mark final deliberation step complete in progress bar
   bar.increment()
+  // Adjust total to reflect actual work in case chains finished early
+  bar.setTotal((bar as any).value)
   bar.stop()
 }
 


### PR DESCRIPTION
## Summary
- adjust progress bar totals when chains finish early

## Testing
- `npx tsc --noEmit grok3-pro.ts grok3-pro-simple.ts`


------
https://chatgpt.com/codex/tasks/task_e_684e5fbd7fb4832db5362de7fe2c5ce0