### PR TITLE
Switch to YAML config with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ export OPENAI_API_KEY="sk-your-openai-key"
 pnpm start -- --model xai:grok-3-mini
 ```
 
-Run without flags to launch an interactive menu for selecting the model(s) to benchmark and the evaluator model. Use `--evaluator` to choose which model scores the answers and `--prompts` to load a custom prompts file.
+Defaults are read from `config.yaml` if it exists. You can override them with CLI flags or by using the interactive menu (`--interactive`). The file lets you set the models, evaluator, and prompts path.
 
 ---
 

--- a/cli.tsx
+++ b/cli.tsx
@@ -56,6 +56,8 @@ import { generateText } from 'ai'
 import { xai } from '@ai-sdk/xai'
 import { openai } from '@ai-sdk/openai'
 import * as fs from 'node:fs/promises'
+import { existsSync, readFileSync } from 'node:fs'
+import { parse as parseYaml } from 'yaml'
 
 interface PromptItem {
   id: string
@@ -194,6 +196,21 @@ function parseArgs() {
   let evaluator = ''
   let promptsPath = 'prompts.json'
   let interactive = false
+
+  if (existsSync('config.yaml')) {
+    try {
+      const data = parseYaml(readFileSync('config.yaml', 'utf8')) as any
+      if (Array.isArray(data.models)) {
+        targets = data.models.map((m: any) => String(m))
+      }
+      if (typeof data.evaluator === 'string') {
+        evaluator = data.evaluator
+      }
+      if (typeof data.prompts === 'string') {
+        promptsPath = data.prompts
+      }
+    } catch {}
+  }
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
     if (arg === '--model' || arg === '--models') {

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+models:
+  - xai:grok-3-mini
+evaluator: xai:grok-3-mini
+prompts: prompts.json

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "ink-text-input": "^6.0.0",
     "ink-spinner": "^5.0.0",
     "react": "^18.2.0",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "yaml": "^2.3.2"
   },
   "devDependencies": {
     "@types/node": "^20.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.0)(typescript@5.8.3)
+      yaml:
+        specifier: ^2.3.2
+        version: 2.8.0
     devDependencies:
       '@types/node':
         specifier: ^20.14.2
@@ -628,6 +631,11 @@ packages:
       utf-8-validate:
         optional: true
 
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -1119,6 +1127,8 @@ snapshots:
       strip-ansi: 7.1.0
 
   ws@8.18.2: {}
+
+  yaml@2.8.0: {}
 
   yn@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- add `yaml` dependency
- support `config.yaml` for default CLI settings
- mention config file in the README

## Testing
- `pnpm install`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_684e8ec32a1c832d89e3b7458c98d1c7